### PR TITLE
Added "text.embedded" to the default of markdown-cell-highlight.targetScopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install:
 
 ## config
 
-- `markdown-cell-highlight.targetScopes`: If specified, this package will highlight code cells with the specified languages scopes. By default (i.e. `["source.embedded"]`), it will highlight _every_ code cell even without language scope. E.g.: if you only want to highlight Julia code cells, you can modify this config into `["source.embedded.julia"]`.
+- `markdown-cell-highlight.targetScopes`: If specified, this package will highlight code cells with the specified languages scopes. By default (i.e. `["source.embedded", "text.embedded"]`), it will highlight _every_ code cell even without language scope. E.g.: if you only want to highlight Julia code cells, you can modify this config into `["source.embedded.julia"]`.
 - `markdown-cell-highlight.markdownScopes`: Specifies grammar scopes that this package will consider as markdown files and try to highlight code cells. Set to `["text.md", "source.gfm", "source.weave.md", "source.pweave.md"]` by default.
 
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
       "title": "Target Scopes",
       "type": "array",
       "default": [
-        "source.embedded"
+        "source.embedded",
+        "text.embedded"
       ],
-      "description": "If specified, this package will highlight code cells with the specified languages scopes. By default (i.e. `[\"source.embedded\"]`), it will highlight _every_ code cell even without language scope. E.g.: if you _only_ want to highlight Julia code cells, you can modify this config into `[\"source.embedded.julia\"]`.",
+      "description": "If specified, this package will highlight code cells with the specified languages scopes. By default (i.e. `[\"source.embedded\", \"text.embedded\"]`), it will highlight _every_ code cell even without language scope. E.g.: if you _only_ want to highlight Julia code cells, you can modify this config into `[\"source.embedded.julia\"]`.",
       "order": 1
     },
     "markdownScopes": {


### PR DESCRIPTION
For example, in HTML and Markdown, cell highlighting is not reflected unless we add `"text.embedded"` to `markdown-cell-highlight.targetScopes`.
So, I added `"text.embedded"` to the default.

I solved it with this change, but if you have a better way to do it, please close this PR.

before
<img width="591" alt="before" src="https://user-images.githubusercontent.com/38322494/82630285-3b441380-9c2d-11ea-9ed3-c136a2727d06.png">

after
<img width="591" alt="after" src="https://user-images.githubusercontent.com/38322494/82630287-3e3f0400-9c2d-11ea-863c-2c74d3df75ac.png">

